### PR TITLE
(architectures|eda): Add OrderTrackingService for Order Status Tracking

### DIFF
--- a/architectures/eda/cheesy-events/cheesy-events.go
+++ b/architectures/eda/cheesy-events/cheesy-events.go
@@ -32,9 +32,9 @@ func main() {
 
 	// Place an order
 	orderService.PlaceOrder("1", "Margherita")
-	orderService.PlaceOrder("1", "Margherita")
-	orderService.PlaceOrder("1", "Margherita")
-	orderService.PlaceOrder("1", "Margherita")
+	orderService.PlaceOrder("2", "BBQ Chicken")
+	orderService.PlaceOrder("3", "Pepperoni")
+	orderService.PlaceOrder("4", "Vegetarian")
 
 	time.Sleep(2 * time.Second)
 }

--- a/architectures/eda/cheesy-events/cheesy-events.go
+++ b/architectures/eda/cheesy-events/cheesy-events.go
@@ -16,39 +16,15 @@ func main() {
 
 	// Create the services
 	orderService := orders.NewOrderService(eventBus)
-	kitchenService := kitchen.NewKitchenService(eventBus, 2)
-	deliveryService := delivery.NewDeliveryService(eventBus)
-	trackingService := tracking.NewOrderTrackingService(eventBus)
-
-	// Create channels for the events
-	orderPlacedChan := make(chan eventbus.Event)
-	orderAcceptedChan := make(chan eventbus.Event)
-	pizzaBeingPreparedChan := make(chan eventbus.Event)
-	pizzaPreparedChan := make(chan eventbus.Event)
-	outForDeliveryChan := make(chan eventbus.Event)
-	deliveredChan := make(chan eventbus.Event)
-
-	// Subscribe the channels to the events
-	eventBus.Subscribe("OrderPlaced", orderPlacedChan)
-	eventBus.Subscribe("OrderAccepted", orderAcceptedChan)
-	eventBus.Subscribe("PizzaBeingPrepared", pizzaBeingPreparedChan)
-	eventBus.Subscribe("PizzaPrepared", pizzaPreparedChan)
-	eventBus.Subscribe("OutForDelivery", outForDeliveryChan)
-	eventBus.Subscribe("Delivered", deliveredChan)
-
-	// Start the event handlers
-	go kitchenService.PreparePizza(orderPlacedChan)
-	go deliveryService.DeliverPizza(pizzaPreparedChan)
-	go trackingService.TrackOrderStatus(orderAcceptedChan)
-	go trackingService.TrackOrderStatus(pizzaBeingPreparedChan)
-	go trackingService.TrackOrderStatus(outForDeliveryChan)
-	go trackingService.TrackOrderStatus(deliveredChan)
+	kitchen.NewKitchenService(eventBus, 2)
+	delivery.NewDeliveryService(eventBus)
+	tracking.NewOrderTrackingService(eventBus)
 
 	// Place an order
 	orderService.PlaceOrder("1", "Margherita")
-	orderService.PlaceOrder("2", "BBQ Chicken")
-	orderService.PlaceOrder("3", "Pepperoni")
-	orderService.PlaceOrder("4", "Vegetarian")
+	//orderService.PlaceOrder("2", "BBQ Chicken")
+	//orderService.PlaceOrder("3", "Pepperoni")
+	//orderService.PlaceOrder("4", "Vegetarian")
 
 	time.Sleep(2 * time.Second)
 }

--- a/architectures/eda/cheesy-events/cheesy-events.go
+++ b/architectures/eda/cheesy-events/cheesy-events.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cheesy-events/tracking"
 	"time"
 
 	"cheesy-events/delivery"
@@ -17,18 +18,31 @@ func main() {
 	orderService := orders.NewOrderService(eventBus)
 	kitchenService := kitchen.NewKitchenService(eventBus, 2)
 	deliveryService := delivery.NewDeliveryService(eventBus)
+	trackingService := tracking.NewOrderTrackingService(eventBus)
 
 	// Create channels for the events
 	orderPlacedChan := make(chan eventbus.Event)
+	orderAcceptedChan := make(chan eventbus.Event)
+	pizzaBeingPreparedChan := make(chan eventbus.Event)
 	pizzaPreparedChan := make(chan eventbus.Event)
+	outForDeliveryChan := make(chan eventbus.Event)
+	deliveredChan := make(chan eventbus.Event)
 
 	// Subscribe the channels to the events
 	eventBus.Subscribe("OrderPlaced", orderPlacedChan)
+	eventBus.Subscribe("OrderAccepted", orderAcceptedChan)
+	eventBus.Subscribe("PizzaBeingPrepared", pizzaBeingPreparedChan)
 	eventBus.Subscribe("PizzaPrepared", pizzaPreparedChan)
+	eventBus.Subscribe("OutForDelivery", outForDeliveryChan)
+	eventBus.Subscribe("Delivered", deliveredChan)
 
 	// Start the event handlers
 	go kitchenService.PreparePizza(orderPlacedChan)
 	go deliveryService.DeliverPizza(pizzaPreparedChan)
+	go trackingService.TrackOrderStatus(orderAcceptedChan)
+	go trackingService.TrackOrderStatus(pizzaBeingPreparedChan)
+	go trackingService.TrackOrderStatus(outForDeliveryChan)
+	go trackingService.TrackOrderStatus(deliveredChan)
 
 	// Place an order
 	orderService.PlaceOrder("1", "Margherita")

--- a/architectures/eda/cheesy-events/delivery/service.go
+++ b/architectures/eda/cheesy-events/delivery/service.go
@@ -14,6 +14,18 @@ type PizzaDeliveredEvent struct {
 	Pizza   string
 }
 
+// OutForDeliveryEvent represents the event structure for out for delivery status
+type OutForDeliveryEvent struct {
+	OrderID string
+	Status  string
+}
+
+// DeliveredEvent represents the event structure for delivered status
+type DeliveredEvent struct {
+	OrderID string
+	Status  string
+}
+
 // DeliveryService represents the service responsible for pizza delivery
 type DeliveryService struct {
 	eventBus *eventbus.EventBus
@@ -35,19 +47,32 @@ func (ds *DeliveryService) DeliverPizza(eventChan <-chan eventbus.Event) {
 			continue
 		}
 
-		// Simulate pizza delivery
-		fmt.Printf("Pizza delivered: OrderID=%s, Pizza=%s\n", pizzaPreparedEvent.OrderID, pizzaPreparedEvent.Pizza)
-
-		deliveryInProgressEvent := eventbus.Event{
-			Type:      "PizzaPrepared",
+		// Create the out for delivery event
+		outForDeliveryEvent := eventbus.Event{
+			Type:      "OutForDelivery",
 			Timestamp: time.Now(),
-			Data: PizzaDeliveredEvent{
+			Data: OutForDeliveryEvent{
 				OrderID: pizzaPreparedEvent.OrderID,
-				Pizza:   pizzaPreparedEvent.Pizza,
+				Status:  "Out For Delivery",
 			},
 		}
+		ds.PrintEvent(outForDeliveryEvent)
+		ds.eventBus.Publish(outForDeliveryEvent)
 
-		ds.PrintEvent(deliveryInProgressEvent)
+		fmt.Println("Delivering pizza....")
+		time.Sleep(1 * time.Second)
+
+		// Create the delivered event
+		deliveredEvent := eventbus.Event{
+			Type:      "Delivered",
+			Timestamp: time.Now(),
+			Data: DeliveredEvent{
+				OrderID: pizzaPreparedEvent.OrderID,
+				Status:  "Delivered",
+			},
+		}
+		ds.PrintEvent(deliveredEvent)
+		ds.eventBus.Publish(deliveredEvent)
 	}
 }
 

--- a/architectures/eda/cheesy-events/delivery/service.go
+++ b/architectures/eda/cheesy-events/delivery/service.go
@@ -2,10 +2,17 @@ package delivery
 
 import (
 	"fmt"
+	"time"
 
 	"cheesy-events/eventbus"
 	"cheesy-events/kitchen"
 )
+
+// DeliveryInProgressEvent represents the event structure for pizza delivery in progress
+type PizzaDeliveredEvent struct {
+	OrderID string
+	Pizza   string
+}
 
 // DeliveryService represents the service responsible for pizza delivery
 type DeliveryService struct {
@@ -30,5 +37,20 @@ func (ds *DeliveryService) DeliverPizza(eventChan <-chan eventbus.Event) {
 
 		// Simulate pizza delivery
 		fmt.Printf("Pizza delivered: OrderID=%s, Pizza=%s\n", pizzaPreparedEvent.OrderID, pizzaPreparedEvent.Pizza)
+
+		deliveryInProgressEvent := eventbus.Event{
+			Type:      "PizzaPrepared",
+			Timestamp: time.Now(),
+			Data: PizzaDeliveredEvent{
+				OrderID: pizzaPreparedEvent.OrderID,
+				Pizza:   pizzaPreparedEvent.Pizza,
+			},
+		}
+
+		ds.PrintEvent(deliveryInProgressEvent)
 	}
+}
+
+func (ds *DeliveryService) PrintEvent(event eventbus.Event) {
+	fmt.Printf("Publish Event: %s\n", event.Type)
 }

--- a/architectures/eda/cheesy-events/delivery/service.go
+++ b/architectures/eda/cheesy-events/delivery/service.go
@@ -1,18 +1,15 @@
 package delivery
 
 import (
-	"fmt"
+	"cheesy-events/utils/logrus"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"cheesy-events/eventbus"
 	"cheesy-events/kitchen"
 )
 
-// DeliveryInProgressEvent represents the event structure for pizza delivery in progress
-type PizzaDeliveredEvent struct {
-	OrderID string
-	Pizza   string
-}
+var logger = logrus.NewLogger("kitchen")
 
 // OutForDeliveryEvent represents the event structure for out for delivery status
 type OutForDeliveryEvent struct {
@@ -33,49 +30,60 @@ type DeliveryService struct {
 
 // NewDeliveryService creates a new instance of the delivery service
 func NewDeliveryService(eventBus *eventbus.EventBus) *DeliveryService {
-	return &DeliveryService{
+	pizzaPreparedChan := make(chan eventbus.Event)
+	eventBus.Subscribe("PizzaPrepared", pizzaPreparedChan)
+
+	ds := &DeliveryService{
 		eventBus: eventBus,
 	}
+
+	go ds.subscribe(pizzaPreparedChan)
+
+	return ds
 }
 
-// DeliverPizza delivers a pizza when a pizza prepared event is received
-func (ds *DeliveryService) DeliverPizza(eventChan <-chan eventbus.Event) {
+func (ds *DeliveryService) onPizzaPrepared(pizzaPreparedEvent kitchen.PizzaPreparedEvent) {
+	// Create the out for delivery event
+	outForDeliveryEvent := eventbus.Event{
+		Type:      "OutForDelivery",
+		Timestamp: time.Now(),
+		Data: OutForDeliveryEvent{
+			OrderID: pizzaPreparedEvent.OrderID,
+			Status:  "Out For Delivery",
+		},
+	}
+	ds.eventBus.Publish(outForDeliveryEvent)
+	logger.WithFields(log.Fields{
+		"order_id": pizzaPreparedEvent.OrderID,
+		"pizza":    pizzaPreparedEvent.Pizza,
+	}).Info("Delivering pizza....")
+
+	time.Sleep(1 * time.Second)
+
+	// Create the delivered event
+	deliveredEvent := eventbus.Event{
+		Type:      "Delivered",
+		Timestamp: time.Now(),
+		Data: DeliveredEvent{
+			OrderID: pizzaPreparedEvent.OrderID,
+			Status:  "Delivered",
+		},
+	}
+	logger.WithFields(log.Fields{
+		"order_id": pizzaPreparedEvent.OrderID,
+		"pizza":    pizzaPreparedEvent.Pizza,
+	}).Info("Pizza delivered")
+	ds.eventBus.Publish(deliveredEvent)
+}
+
+// subscribe delivers a pizza when a pizza prepared event is received
+func (ds *DeliveryService) subscribe(eventChan <-chan eventbus.Event) {
 	for event := range eventChan {
 		pizzaPreparedEvent, ok := event.Data.(kitchen.PizzaPreparedEvent)
 		if !ok {
-			fmt.Println("Invalid event data")
+			logger.Error("Invalid event data")
 			continue
 		}
-
-		// Create the out for delivery event
-		outForDeliveryEvent := eventbus.Event{
-			Type:      "OutForDelivery",
-			Timestamp: time.Now(),
-			Data: OutForDeliveryEvent{
-				OrderID: pizzaPreparedEvent.OrderID,
-				Status:  "Out For Delivery",
-			},
-		}
-		ds.PrintEvent(outForDeliveryEvent)
-		ds.eventBus.Publish(outForDeliveryEvent)
-
-		fmt.Println("Delivering pizza....")
-		time.Sleep(1 * time.Second)
-
-		// Create the delivered event
-		deliveredEvent := eventbus.Event{
-			Type:      "Delivered",
-			Timestamp: time.Now(),
-			Data: DeliveredEvent{
-				OrderID: pizzaPreparedEvent.OrderID,
-				Status:  "Delivered",
-			},
-		}
-		ds.PrintEvent(deliveredEvent)
-		ds.eventBus.Publish(deliveredEvent)
+		ds.onPizzaPrepared(pizzaPreparedEvent)
 	}
-}
-
-func (ds *DeliveryService) PrintEvent(event eventbus.Event) {
-	fmt.Printf("Publish Event: %s\n", event.Type)
 }

--- a/architectures/eda/cheesy-events/go.mod
+++ b/architectures/eda/cheesy-events/go.mod
@@ -1,3 +1,8 @@
 module cheesy-events
 
 go 1.22
+
+require (
+	github.com/sirupsen/logrus v1.9.3 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/architectures/eda/cheesy-events/go.sum
+++ b/architectures/eda/cheesy-events/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/architectures/eda/cheesy-events/kitchen/kitchen.go
+++ b/architectures/eda/cheesy-events/kitchen/kitchen.go
@@ -14,6 +14,12 @@ type PizzaPreparedEvent struct {
 	Pizza   string
 }
 
+// PizzaBeingPreparedEvent represents the event structure for pizza preparation status
+type PizzaBeingPreparedEvent struct {
+	OrderID string
+	Status  string
+}
+
 // KitchenService represents the service responsible for pizza preparation
 type KitchenService struct {
 	eventBus       *eventbus.EventBus
@@ -45,8 +51,22 @@ func (ks *KitchenService) PreparePizza(eventChan <-chan eventbus.Event) {
 		}
 
 		// Simulate pizza preparation
-		fmt.Printf("Pizza prepared: OrderID=%s, Pizza=%s\n", orderPlacedEvent.OrderID, orderPlacedEvent.Pizza)
+		fmt.Printf("Pizza being prepared: OrderID=%s, Pizza=%s\n", orderPlacedEvent.OrderID, orderPlacedEvent.Pizza)
 
+		// Create the pizza being prepared event
+		preparingEvent := eventbus.Event{
+			Type:      "PizzaBeingPrepared",
+			Timestamp: time.Now(),
+			Data: PizzaBeingPreparedEvent{
+				OrderID: orderPlacedEvent.OrderID,
+				Status:  "Pizza Being Prepared",
+			},
+		}
+		ks.PrintEvent(preparingEvent)
+		ks.eventBus.Publish(preparingEvent)
+
+		fmt.Println("Preparing pizza....")
+		time.Sleep(1 * time.Second)
 		// Create the pizza prepared event
 		event := eventbus.Event{
 			Type:      "PizzaPrepared",
@@ -57,8 +77,6 @@ func (ks *KitchenService) PreparePizza(eventChan <-chan eventbus.Event) {
 			},
 		}
 		ks.PrintEvent(event)
-
-		// Publish the event
 		ks.eventBus.Publish(event)
 
 		// Increment the number of pizzas prepared

--- a/architectures/eda/cheesy-events/kitchen/kitchen.go
+++ b/architectures/eda/cheesy-events/kitchen/kitchen.go
@@ -56,6 +56,7 @@ func (ks *KitchenService) PreparePizza(eventChan <-chan eventbus.Event) {
 				Pizza:   orderPlacedEvent.Pizza,
 			},
 		}
+		ks.PrintEvent(event)
 
 		// Publish the event
 		ks.eventBus.Publish(event)
@@ -63,4 +64,8 @@ func (ks *KitchenService) PreparePizza(eventChan <-chan eventbus.Event) {
 		// Increment the number of pizzas prepared
 		ks.pizzasPrepared++
 	}
+}
+
+func (ks *KitchenService) PrintEvent(event eventbus.Event) {
+	fmt.Printf("Publish Event: %s\n", event.Type)
 }

--- a/architectures/eda/cheesy-events/orders/service.go
+++ b/architectures/eda/cheesy-events/orders/service.go
@@ -19,6 +19,12 @@ func NewOrderService(eventBus *eventbus.EventBus) *OrderService {
 	}
 }
 
+// OrderAcceptedEvent represents the event structure for order acceptance
+type OrderAcceptedEvent struct {
+	OrderID string
+	Status  string
+}
+
 // OrderPlacedEvent represents the event structure for order placement
 type OrderPlacedEvent struct {
 	OrderID string
@@ -43,6 +49,21 @@ func (os *OrderService) PlaceOrder(orderID, pizza string) {
 
 	// Publish the event
 	os.eventBus.Publish(event)
+
+	fmt.Printf("Checking Fraud system....: %s\n", event.Type)
+	time.Sleep(1 * time.Second)
+
+	// Simulate order acceptance
+	acceptedEvent := eventbus.Event{
+		Type:      "OrderAccepted",
+		Timestamp: time.Now(),
+		Data: OrderAcceptedEvent{
+			OrderID: orderID,
+			Status:  "Order Accepted",
+		},
+	}
+	os.PrintEvent(acceptedEvent)
+	os.eventBus.Publish(acceptedEvent)
 }
 
 func (os *OrderService) PrintEvent(event eventbus.Event) {

--- a/architectures/eda/cheesy-events/orders/service.go
+++ b/architectures/eda/cheesy-events/orders/service.go
@@ -1,11 +1,14 @@
 package orders
 
 import (
-	"fmt"
+	"cheesy-events/utils/logrus"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"cheesy-events/eventbus"
 )
+
+var logger = logrus.NewLogger("orders")
 
 // OrderService represents the service responsible for order placement
 type OrderService struct {
@@ -22,6 +25,7 @@ func NewOrderService(eventBus *eventbus.EventBus) *OrderService {
 // OrderAcceptedEvent represents the event structure for order acceptance
 type OrderAcceptedEvent struct {
 	OrderID string
+	Pizza   string
 	Status  string
 }
 
@@ -29,12 +33,16 @@ type OrderAcceptedEvent struct {
 type OrderPlacedEvent struct {
 	OrderID string
 	Pizza   string
+	Status  string
 }
 
 // PlaceOrder places a new order and publishes an order placed event
 func (os *OrderService) PlaceOrder(orderID, pizza string) {
 	// Simulate order placement
-	fmt.Printf("Order placed: OrderID=%s, Pizza=%s\n", orderID, pizza)
+	logger.WithFields(log.Fields{
+		"order_id": orderID,
+		"pizza":    pizza,
+	}).Info("Order placed")
 
 	// Create the order placed event
 	event := eventbus.Event{
@@ -43,14 +51,18 @@ func (os *OrderService) PlaceOrder(orderID, pizza string) {
 		Data: OrderPlacedEvent{
 			OrderID: orderID,
 			Pizza:   pizza,
+			Status:  "Order Placed",
 		},
 	}
-	os.PrintEvent(event)
 
 	// Publish the event
 	os.eventBus.Publish(event)
 
-	fmt.Printf("Checking Fraud system....: %s\n", event.Type)
+	logger.WithFields(log.Fields{
+		"order_id": orderID,
+		"pizza":    pizza,
+	}).Info("Checking Fraud system....")
+
 	time.Sleep(1 * time.Second)
 
 	// Simulate order acceptance
@@ -59,13 +71,9 @@ func (os *OrderService) PlaceOrder(orderID, pizza string) {
 		Timestamp: time.Now(),
 		Data: OrderAcceptedEvent{
 			OrderID: orderID,
+			Pizza:   pizza,
 			Status:  "Order Accepted",
 		},
 	}
-	os.PrintEvent(acceptedEvent)
 	os.eventBus.Publish(acceptedEvent)
-}
-
-func (os *OrderService) PrintEvent(event eventbus.Event) {
-	fmt.Printf("Publish Event: %s\n", event.Type)
 }

--- a/architectures/eda/cheesy-events/orders/service.go
+++ b/architectures/eda/cheesy-events/orders/service.go
@@ -46,5 +46,5 @@ func (os *OrderService) PlaceOrder(orderID, pizza string) {
 }
 
 func (os *OrderService) PrintEvent(event eventbus.Event) {
-	fmt.Printf("Event: %s\n", event.Type)
+	fmt.Printf("Publish Event: %s\n", event.Type)
 }

--- a/architectures/eda/cheesy-events/readme.md
+++ b/architectures/eda/cheesy-events/readme.md
@@ -27,3 +27,29 @@
 3. **Pizza Delivery**:
     - The `DeliveryService` listens for `PizzaPrepared` events.
     - Upon receiving the event, it delivers the pizza to the customer.
+
+### Desired feature:
+Feature: Real-time Order Tracking
+- Order Tracking
+Description: Allow customers to track the status of their order in real-time.
+Implementation: Publish events like OrderAccepted, PizzaBeingPrepared, OutForDelivery, and Delivered.
+
+```mermaid
+sequenceDiagram
+    participant Customer
+    participant OrdersService
+    participant KitchenService
+    participant DeliveryService
+    participant OrderTrackingService
+
+    Customer->>OrdersService: Place Order
+    OrdersService->>OrderTrackingService: OrderPlaced
+    OrdersService->>OrderTrackingService: OrderAccepted
+    OrdersService->>KitchenService: OrderPlaced
+    KitchenService->>OrderTrackingService: PizzaBeingPrepared
+    KitchenService->>OrderTrackingService: PizzaPrepared
+    KitchenService->>DeliveryService: PizzaPrepared
+    DeliveryService->>OrderTrackingService: OutForDelivery
+    DeliveryService->>OrderTrackingService: Delivered
+    DeliveryService->>Customer: Pizza Delivered
+```

--- a/architectures/eda/cheesy-events/readme.md
+++ b/architectures/eda/cheesy-events/readme.md
@@ -45,7 +45,7 @@ sequenceDiagram
     Customer->>OrdersService: Place Order
     OrdersService->>OrderTrackingService: OrderPlaced
     OrdersService->>OrderTrackingService: OrderAccepted
-    OrdersService->>KitchenService: OrderPlaced
+    OrdersService->>KitchenService: OrderAccepted
     KitchenService->>OrderTrackingService: PizzaBeingPrepared
     KitchenService->>OrderTrackingService: PizzaPrepared
     KitchenService->>DeliveryService: PizzaPrepared

--- a/architectures/eda/cheesy-events/readme.md
+++ b/architectures/eda/cheesy-events/readme.md
@@ -1,0 +1,29 @@
+### Domains and Responsibilities
+
+1. **Orders**
+    - **Responsibility**: Handles the placement of pizza orders.
+    - **Use Case**: A customer places an order for a pizza, which triggers an `OrderPlaced` event.
+
+2. **Kitchen**
+    - **Responsibility**: Prepares pizzas based on the orders received.
+    - **Use Case**: Upon receiving an `OrderPlaced` event, the kitchen prepares the pizza and triggers a `PizzaPrepared` event.
+    - **Business Rule**: The kitchen cannot prepare more than the maximum number of pizzas (`maxPizzas`). If the limit is reached, no more pizzas will be prepared, and a message will be logged.
+
+3. **Delivery**
+    - **Responsibility**: Manages the delivery of prepared pizzas.
+    - **Use Case**: Upon receiving a `PizzaPrepared` event, the delivery service delivers the pizza to the customer.
+
+### Use Case Example
+
+1. **Order Placement**:
+    - A customer places an order for a "Margherita" pizza.
+    - The `OrderService` publishes an `OrderPlaced` event.
+
+2. **Pizza Preparation**:
+    - The `KitchenService` listens for `OrderPlaced` events.
+    - Upon receiving the event, it prepares the pizza and publishes a `PizzaPrepared` event.
+    - If the maximum number of pizzas (`maxPizzas`) has been prepared, no more pizzas will be prepared, and a message will be logged.
+
+3. **Pizza Delivery**:
+    - The `DeliveryService` listens for `PizzaPrepared` events.
+    - Upon receiving the event, it delivers the pizza to the customer.

--- a/architectures/eda/cheesy-events/tracking/service.go
+++ b/architectures/eda/cheesy-events/tracking/service.go
@@ -1,0 +1,39 @@
+package tracking
+
+import (
+	"cheesy-events/delivery"
+	"cheesy-events/eventbus"
+	"cheesy-events/kitchen"
+	"cheesy-events/orders"
+	"fmt"
+)
+
+// OrderTrackingService represents the service responsible for tracking order status
+type OrderTrackingService struct {
+	eventBus *eventbus.EventBus
+}
+
+// NewOrderTrackingService creates a new instance of the order tracking service
+func NewOrderTrackingService(eventBus *eventbus.EventBus) *OrderTrackingService {
+	return &OrderTrackingService{
+		eventBus: eventBus,
+	}
+}
+
+// TrackOrderStatus listens for order status events and updates the order status
+func (ots *OrderTrackingService) TrackOrderStatus(eventChan <-chan eventbus.Event) {
+	for event := range eventChan {
+		switch e := event.Data.(type) {
+		case orders.OrderAcceptedEvent:
+			fmt.Printf("Order accepted: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+		case kitchen.PizzaBeingPreparedEvent:
+			fmt.Printf("Pizza being prepared: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+		case delivery.OutForDeliveryEvent:
+			fmt.Printf("Out for delivery: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+		case delivery.DeliveredEvent:
+			fmt.Printf("Delivered: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+		default:
+			fmt.Println("Unknown event type")
+		}
+	}
+}

--- a/architectures/eda/cheesy-events/tracking/service.go
+++ b/architectures/eda/cheesy-events/tracking/service.go
@@ -5,8 +5,11 @@ import (
 	"cheesy-events/eventbus"
 	"cheesy-events/kitchen"
 	"cheesy-events/orders"
-	"fmt"
+	"cheesy-events/utils/logrus"
+	log "github.com/sirupsen/logrus"
 )
+
+var logger = logrus.NewLogger("tracking")
 
 // OrderTrackingService represents the service responsible for tracking order status
 type OrderTrackingService struct {
@@ -15,25 +18,85 @@ type OrderTrackingService struct {
 
 // NewOrderTrackingService creates a new instance of the order tracking service
 func NewOrderTrackingService(eventBus *eventbus.EventBus) *OrderTrackingService {
-	return &OrderTrackingService{
+
+	// Create channels for the events
+	orderPlacedChan := make(chan eventbus.Event)
+	orderAcceptedChan := make(chan eventbus.Event)
+	pizzaBeingPreparedChan := make(chan eventbus.Event)
+	outForDeliveryChan := make(chan eventbus.Event)
+	deliveredChan := make(chan eventbus.Event)
+
+	// subscribe the channels to the events
+	eventBus.Subscribe("OrderPlaced", orderPlacedChan)
+	eventBus.Subscribe("OrderAccepted", orderAcceptedChan)
+	eventBus.Subscribe("PizzaBeingPrepared", pizzaBeingPreparedChan)
+	eventBus.Subscribe("OutForDelivery", outForDeliveryChan)
+	eventBus.Subscribe("Delivered", deliveredChan)
+
+	ots := &OrderTrackingService{
 		eventBus: eventBus,
 	}
+
+	go ots.subscribe(orderPlacedChan)
+	go ots.subscribe(orderAcceptedChan)
+	go ots.subscribe(pizzaBeingPreparedChan)
+	go ots.subscribe(outForDeliveryChan)
+	go ots.subscribe(deliveredChan)
+
+	return ots
 }
 
-// TrackOrderStatus listens for order status events and updates the order status
-func (ots *OrderTrackingService) TrackOrderStatus(eventChan <-chan eventbus.Event) {
+func (ots *OrderTrackingService) onOrderPlaced(orderPlacedEvent orders.OrderPlacedEvent) {
+	logger.WithFields(log.Fields{
+		"order_id": orderPlacedEvent.OrderID,
+		"Status":   orderPlacedEvent.Status,
+	}).Info("Order placed")
+}
+
+func (ots *OrderTrackingService) onOrderAccepted(orderAcceptedEvent orders.OrderAcceptedEvent) {
+	logger.WithFields(log.Fields{
+		"order_id": orderAcceptedEvent.OrderID,
+		"Status":   orderAcceptedEvent.Status,
+	}).Info("Order accepted")
+}
+
+func (ots *OrderTrackingService) onPizzaBeingPrepared(pizzaBeingPreparedEvent kitchen.PizzaBeingPreparedEvent) {
+	logger.WithFields(log.Fields{
+		"order_id": pizzaBeingPreparedEvent.OrderID,
+		"Status":   pizzaBeingPreparedEvent.Status,
+	}).Info("Pizza being prepared")
+}
+
+func (ots *OrderTrackingService) onOutForDelivery(outForDeliveryEvent delivery.OutForDeliveryEvent) {
+	logger.WithFields(log.Fields{
+		"order_id": outForDeliveryEvent.OrderID,
+		"Status":   outForDeliveryEvent.Status,
+	}).Info("Out for delivery")
+}
+
+func (ots *OrderTrackingService) onDelivered(deliveredEvent delivery.DeliveredEvent) {
+	logger.WithFields(log.Fields{
+		"order_id": deliveredEvent.OrderID,
+		"Status":   deliveredEvent.Status,
+	}).Info("Delivered")
+}
+
+// subscribe listens for order status events and updates the order status
+func (ots *OrderTrackingService) subscribe(eventChan <-chan eventbus.Event) {
 	for event := range eventChan {
 		switch e := event.Data.(type) {
+		case orders.OrderPlacedEvent:
+			ots.onOrderPlaced(e)
 		case orders.OrderAcceptedEvent:
-			fmt.Printf("Order accepted: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+			ots.onOrderAccepted(e)
 		case kitchen.PizzaBeingPreparedEvent:
-			fmt.Printf("Pizza being prepared: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+			ots.onPizzaBeingPrepared(e)
 		case delivery.OutForDeliveryEvent:
-			fmt.Printf("Out for delivery: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+			ots.onOutForDelivery(e)
 		case delivery.DeliveredEvent:
-			fmt.Printf("Delivered: OrderID=%s, Status=%s\n", e.OrderID, e.Status)
+			ots.onDelivered(e)
 		default:
-			fmt.Println("Unknown event type")
+			logger.Error("Unknown event type")
 		}
 	}
 }

--- a/architectures/eda/cheesy-events/utils/logrus/logger.go
+++ b/architectures/eda/cheesy-events/utils/logrus/logger.go
@@ -1,0 +1,20 @@
+package logrus
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+)
+
+var log *logrus.Logger
+
+func init() {
+	log = logrus.New()
+	log.SetOutput(os.Stdout)
+	log.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: false,
+	})
+}
+
+func NewLogger(module string) *logrus.Entry {
+	return log.WithField("Module", module)
+}

--- a/code-metrics/generate_pr_metrics.py
+++ b/code-metrics/generate_pr_metrics.py
@@ -75,20 +75,27 @@ if __name__ == '__main__':
 
     # load dataset_main_metrics.csv to compare the metrics
     df_main = pd.read_csv('./code-metrics/dataset_main_metrics.csv')
+
     # Merge the two dataframes and apply the operation subtract to diff the metrics
-    merged_df = pd.merge(df_main, df, on='file', suffixes=('_main', '_pr'))
+    merged_df = pd.merge(df, df_main, on='file', how='left',suffixes=('_main', '_pr'))
+
+    # Fill NaN values with 0
+    merged_df = merged_df.fillna(0)
+
     # Calculate the difference between the metrics
-    merged_df['methods_diff'] = merged_df['number-of-methods-in-file_pr'] - merged_df[
-        'number-of-methods-in-file_main']
-    merged_df['sloc_diff'] = merged_df['sloc-in-file_pr'] - merged_df['sloc-in-file_main']
+    merged_df['methods_diff'] = merged_df['number-of-methods-in-file_main'] - merged_df[
+        'number-of-methods-in-file_pr']
+    #flipped the order of the subtraction to get the correct diff
+
+    merged_df['sloc_diff'] = merged_df['sloc-in-file_main'] - merged_df['sloc-in-file_pr']
     merged_df['louvain_diff'] = merged_df[
-                                                                                    'file_result_dependency_graph_louvain-modularity-in-file_pr'] - \
+                                                                                    'file_result_dependency_graph_louvain-modularity-in-file_main'] - \
                                                                                 merged_df[
-                                                                                    'file_result_dependency_graph_louvain-modularity-in-file_main']
-    merged_df['fan_in_diff'] = merged_df['fan-in-dependency-graph_pr'] - merged_df[
-        'fan-in-dependency-graph_main']
-    merged_df['fan_out_diff'] = merged_df['fan-out-dependency-graph_pr'] - merged_df[
-        'fan-out-dependency-graph_main']
+                                                                                    'file_result_dependency_graph_louvain-modularity-in-file_pr']
+    merged_df['fan_in_diff'] = merged_df['fan-in-dependency-graph_main'] - merged_df[
+        'fan-in-dependency-graph_pr']
+    merged_df['fan_out_diff'] = merged_df['fan-out-dependency-graph_main'] - merged_df[
+        'fan-out-dependency-graph_pr']
 
     # save the merged dataframe to a csv file
     merged_df[['file',


### PR DESCRIPTION
#### Summary
This PR introduces a new `OrderTrackingService` to track the status of pizza orders throughout their lifecycle. The service listens for various events and updates the order status accordingly.

#### Changes
1. **New Events**:
   - `OrderAcceptedEvent`
   - `PizzaBeingPreparedEvent`
   - `OutForDeliveryEvent`
   - `DeliveredEvent`

2. **OrderTrackingService**:
   - Created a new service to handle order status tracking.
   - Listens for the new events and prints the order status updates.

3. **Modifications to Existing Services**:
   - **OrderService**: Publishes `OrderAcceptedEvent` after placing an order.
   - **KitchenService**: Publishes `PizzaBeingPreparedEvent` before preparing a pizza.
   - **DeliveryService**: Publishes `OutForDeliveryEvent` and `DeliveredEvent` during the delivery process.

4. **Main Application (`cheesy-events.go`)**:
   - Subscribed new event channels to the event bus.
   - Started the `OrderTrackingService` to handle the new events.

```
                                                              file  methods_diff  sloc_diff  louvain_diff  fan_in_diff  fan_out_diff
      patterns-go/architectures/eda/cheesy-events/cheesy-events.go           0.0       -7.0           0.0          0.0           1.0
   patterns-go/architectures/eda/cheesy-events/delivery/service.go           1.0       44.0           0.0          0.0           2.0
    patterns-go/architectures/eda/cheesy-events/kitchen/kitchen.go           1.0       30.0           0.0          0.0           1.0
     patterns-go/architectures/eda/cheesy-events/orders/service.go          -1.0       23.0           0.0          0.0           1.0
   patterns-go/architectures/eda/cheesy-events/tracking/service.go           7.0       82.0           1.0          0.0           6.0
patterns-go/architectures/eda/cheesy-events/utils/logrus/logger.go           2.0       16.0           1.0          0.0           2.0

```